### PR TITLE
Cache index.html and serves it from exports

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,16 @@
 const fs = require('fs');
 const path = require('path');
 
+// cache index.html to serve on React routes
+fs.readFile(path.join(__dirname, '../../dist/index.html'), 'utf8', (err, data) => {
+  if (err) {
+    throw new Error(err);
+  } else {
+    exports.index = data;
+  }
+});
+
+// request handlers for server routes
 exports.routes = {
   GET: {
     '/': function getRoot() {
@@ -20,13 +30,7 @@ exports.routes = {
     },
     '/user': function getUser() {
       return new Promise((resolve, reject) => {
-        fs.readFile(path.join(__dirname, '../../dist/index.html'), 'utf8', (err, data) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(data);
-          }
-        });
+        resolve(exports.index);
       });
     },
     '/favicon.ico': function getFavicon() {


### PR DESCRIPTION
Tidies previous hack. Not sure if this is _the_ long-term solution, but it means only one disk read and substantially shorter methods for each server route that reflects a React route.