### PR TITLE
Change API routing to method->url to avoid hasOwnProperty on undefined

### DIFF
--- a/server/request-handler/index.js
+++ b/server/request-handler/index.js
@@ -22,9 +22,8 @@ exports.handler = function handler(req, res) {
 
   // API endpoints
   const urlParts = req.url.split('/');
-  if (urlParts[1] === 'API' &&
-    routes.api[urlParts[2]].hasOwnProperty(req.method)) {
-    routes.api[urlParts[2]][req.method](req)
+  if (urlParts[1] === 'API' && routes.api[req.method].hasOwnProperty(urlParts[2])) {
+    routes.api[req.method][urlParts[2]](req)
       .then((data) => {
         res.statusCode = 200;
         res.json(data);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,8 +3,8 @@ exports.react = new Set(['/user', '/projects']);
 
 // request handlers for server routes
 exports.api = {
-  users: {
-    GET: function getUsers() {
+  GET: {
+    users: function getUsers() {
       return new Promise((resolve) => {
         resolve([
           { userId: 1, username: 'francis' },
@@ -14,9 +14,7 @@ exports.api = {
         ]);
       });
     },
-  },
-  projects: {
-    GET: function getProjects() {
+    projects: function getProjects() {
       return new Promise((resolve) => {
         resolve([
           { projectId: 1,
@@ -34,9 +32,7 @@ exports.api = {
         ]);
       });
     },
-  },
-  'recommended-pairs': {
-    GET: function getProjects() {
+    'recommended-pairs': function getProjects() {
       return new Promise((resolve) => {
         resolve([
           { userId: 2, username: 'p-w-party-m', rating: 89 },


### PR DESCRIPTION
Prior to this, the request handler for API calls was selected from an object with URLs then methods, so it's possible (albeit unlikely) for a request to be made to '/API/not-existing' and have the request handler attempt to call hasOwnProperty on api['not-existing'], which is obviously undefined.

This way, method first, we can be reasonably confident that the first property is on the API routing object.